### PR TITLE
Use bash in vscode

### DIFF
--- a/config/code/settings.json
+++ b/config/code/settings.json
@@ -7,4 +7,5 @@
     "explorer.confirmDragAndDrop": false,
     "editor.fontLigatures": true,
     "editor.lineNumbers": "relative",
+    "terminal.integrated.shell.linux": "/bin/bash",
 }


### PR DESCRIPTION
Anaconda for python was expecting a bash shell, and fish was causing
some problems, so vscode can use bash instead.